### PR TITLE
Wider write permissions (fix tests in Mac/Linux)

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -129,7 +129,7 @@ def _replace_scm_data_in_conanfile(conanfile_path, scm_data):
     new_text = "scm = " + ",\n          ".join(str(scm_data).split(",")) + "\n"
     content = content.replace(to_replace[0], new_text)
     if not os.access(conanfile_path, os.W_OK):
-        os.chmod(conanfile_path, stat.S_IWRITE)
+        os.chmod(conanfile_path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
     save(conanfile_path, content)
 
 

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -68,7 +68,7 @@ def merge_directories(src, dst, excluded=None, symlinks=True):
                 os.symlink(linkto, dst_file)
             else:
                 if os.path.isfile(dst_file) and not os.access(dst_file, os.W_OK):
-                    os.chmod(dst_file, stat.S_IWRITE)
+                    os.chmod(dst_file, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
                 shutil.copy2(src_file, dst_file)
 
 

--- a/conans/test/functional/scm_test.py
+++ b/conans/test/functional/scm_test.py
@@ -562,11 +562,11 @@ class ConanLib(ConanFile):
                       str(self.client.out).lower())
         self.assertIn("My file is copied", self.client.out)
 
-    def test_needs_locked_svn(self):
+    def test_with_locked_svn(self):
         conanfile = base_svn.format(directory="None", url="auto", revision="auto")
         project_url, rev = self.create_project(files={"conanfile.py": conanfile,
                                                       "myfile.txt": "My file is copied"},
-                                               needs_lock=True)
+                                               lock_repo=True)
         project_url = project_url.replace(" ", "%20")
         self.client.runner('svn co "{url}" "{path}"'.format(url=project_url, path=self.client.current_folder))
 

--- a/conans/test/functional/scm_test.py
+++ b/conans/test/functional/scm_test.py
@@ -564,7 +564,8 @@ class ConanLib(ConanFile):
 
     def test_needs_locked_svn(self):
         conanfile = base_svn.format(directory="None", url="auto", revision="auto")
-        project_url, rev = self.create_project(files={"conanfile.py": conanfile, "myfile.txt": "My file is copied"},
+        project_url, rev = self.create_project(files={"conanfile.py": conanfile,
+                                                      "myfile.txt": "My file is copied"},
                                                needs_lock=True)
         project_url = project_url.replace(" ", "%20")
         self.client.runner('svn co "{url}" "{path}"'.format(url=project_url, path=self.client.current_folder))
@@ -575,7 +576,7 @@ class ConanLib(ConanFile):
         sources_dir = self.client.client_cache.scm_folder(self.reference)
         self.assertEquals(load(sources_dir), curdir)
         self.assertIn("Repo origin deduced by 'auto': {}".format(project_url).lower(),
-            str(self.client.out).lower())
+                      str(self.client.out).lower())
         self.assertIn("Revision deduced by 'auto'", self.client.out)
         self.assertIn("Getting sources from folder: %s" % curdir, self.client.out)
         self.assertIn("My file is copied", self.client.out)
@@ -583,7 +584,7 @@ class ConanLib(ConanFile):
         # Export again but now with absolute reference, so no pointer file is created nor kept
         svn = SVN(curdir)
         if not os.access(os.path.join(curdir, "conanfile.py"), os.W_OK):
-            os.chmod(os.path.join(curdir, "conanfile.py"), stat.S_IWRITE)
+            os.chmod(os.path.join(curdir, "conanfile.py"), stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
         self.client.save({"conanfile.py": base_svn.format(url=svn.get_remote_url(), revision=svn.get_revision())})
         self.client.run("create . user/channel", ignore_error=False)
         sources_dir = self.client.client_cache.scm_folder(self.reference)

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -338,7 +338,8 @@ class SVNLocalRepoTestCase(unittest.TestCase):
             os.makedirs(tmp)
         return tmp
 
-    def create_project(self, files, rel_project_path=None, commit_msg='default commit message', delete_checkout=True, needs_lock=False):
+    def create_project(self, files, rel_project_path=None, commit_msg='default commit message',
+                       delete_checkout=True, lock_repo=False):
         tmp_dir = self.gimme_tmp()
         try:
             rel_project_path = rel_project_path or str(uuid.uuid4())
@@ -349,7 +350,7 @@ class SVNLocalRepoTestCase(unittest.TestCase):
             save_files(tmp_project_dir, files)
             with chdir(tmp_project_dir):
                 subprocess.check_output("svn add .", shell=True)
-                if needs_lock:
+                if lock_repo:
                     subprocess.check_output('svn propset svn:needs-lock * . -R', shell=True)
                 subprocess.check_output('svn commit -m "{}"'.format(commit_msg), shell=True)
                 rev = subprocess.check_output("svn info --show-item revision", shell=True).decode().strip()


### PR DESCRIPTION
For Linux/Mac I think that we need wider permissions in order to access the files. Here I'm granting all permissions, let's see if tests work and afterward we may remove some of them.

Related: https://github.com/conan-io/conan/pull/3748